### PR TITLE
Sanitize illegal characters from download filename, by nutzboi

### DIFF
--- a/src/states_screens/dialogs/addons_pack.cpp
+++ b/src/states_screens/dialogs/addons_pack.cpp
@@ -82,6 +82,14 @@ public:
             url.find("http://") != std::string::npos)
         {
             setURL(url);
+            std::string illegal_chars = "/\\:*\"?<>|";
+            for(unsigned i = 0; i < m_filename.size(); i++)
+            {
+                if(illegal_chars.find(m_filename[i]) != std::string::npos)
+                {
+                    m_filename[i] = '-';
+                }
+            }
             setDownloadAssetsRequest(true);
         }
         else


### PR DESCRIPTION
prevent /installaddon failing (especially on windows) when basename contains characters that are illegal in popular filesystems.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
